### PR TITLE
Add utc option, add Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# ember-datepicker Changelog
+
+### 1.2.0 (September 23, 2014)
+
+* add `utc` option flag
+
+### 1.1.0 (September 17, 2014)
+
+* add `allowBlank` option flag
+* introduce tests

--- a/README.md
+++ b/README.md
@@ -5,22 +5,31 @@ This component is an Ember CLI add-on and uses moment.js along with pickaday
 to create an extensible ember component. This is still a work in progress. Pull requests are welcome.
 
 ## Installation
-    npm install ember-cli-datepicker --save-dev
-    ember g ember-cli-datepicker
+```sh
+# install via npm
+$ npm install ember-cli-datepicker --save-dev
+# make ember-cli fetch internal dependencies
+$ ember g ember-cli-datepicker
+```
 
 ## Basic Usage
-
-    {{date-picker date=mydate valueFormat='YYYY-MM-DD'}}
+```handlebars
+{{date-picker date=mydate valueFormat='YYYY-MM-DD'}}
+```
 
 ## Demo
 Check out the demo on [github pages](http://gevious.github.io/ember-datepicker/ "Ember-datepicker Demo").
 Alternatively you can clone this repo and run the app
 
-    sudo npm install -g ember-cli
-    git clone git@github.com:gevious/ember-datepicker
-    cd ember-datepicker
-    npm install; bower install
-    ember serve
+```sh
+$ sudo npm install -g ember-cli
+$ git clone git@github.com:gevious/ember-datepicker
+$ cd ember-datepicker
+# install dependencies
+$ npm install; bower install
+# fire up local server
+$ ember serve
+```
 
 ## Options
 When calling the the datepicker, the following options are available:
@@ -71,3 +80,18 @@ Default: `false`
 Can be set to allow blank dates (`date = null`). By default, `null` values will
 be replaced by the current date on initial render and every time the datepicker
 is closed. With this option, `date` may stay `null`.
+
+#### utc
+Type: `Boolean`
+Default: `false`
+
+Per default, the created `date` value will obtain the computer's timezone and
+therefore not have UTC midnight as its time and will be a few hours off instead.
+
+For example, when your timezone is 8 hours ahead of UTC: Creating a date object
+from the input `"2000-01-01"` will result in `"1999-12-31T16:00:00.000Z"`,
+because when your computer has the time of 00:00:00 on Jan 1st 2000, UTC time is
+still in 1999. This is technically correct, but may not be what you want.
+
+If you want to have easy-to-compare date strings in your JSON, set `utc` to `true`
+and you will get `"2000-01-01T00:00:00.000Z"` as expected.

--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -7,7 +7,8 @@ export default Em.TextField.extend({
   valueFormat: 'X',           // expect unix timestamp format from data binding
   outputFormat: 'YYYY-MM-DD', // the format to display in the text field
   numberOfMonths: 1,          // the "width" of date picker
-  allowBlank: false,          // wheter `null` input/result is acceptable
+  allowBlank: false,          // whether `null` input/result is acceptable
+  utc: false,                 // whether the input value is meant as a UTC date
   date: null,
   yearRange: function() {
     var cy = window.moment().year();
@@ -38,7 +39,9 @@ export default Em.TextField.extend({
            * Format the "outgoing" date with respect to the given`outputFormat`.
            */
           onClose: function() {
-            var d = window.moment(that.get('value'), that.get('outputFormat'));
+            // use `moment` or `moment.utc` depending on `utc` flag
+            var momentFunction = that.get('utc') ? window.moment.utc : window.moment,
+                d = momentFunction(that.get('value'), that.get('outputFormat'));
 
             // has there been a valid date or any value at all?
             if (!d.isValid() || !that.get('value')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-datepicker",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "An Ember datepicker component using Pikaday and momentjs",
   "directories": {
     "doc": "doc",

--- a/tests/unit/date-picker-component-test.js
+++ b/tests/unit/date-picker-component-test.js
@@ -85,6 +85,21 @@ test("it does not set bound date after open + close when `allowBlank: true`", fu
 /**
  * Misc
  */
+test("it shows date picker after click on input field", function() {
+  component = this.subject();
+
+  // initial render
+  this.$();
+
+  equal($('.pika-single').hasClass('is-hidden'), true, "date picker is initially hidden");
+
+  click(this.$());
+
+  andThen(function() {
+    equal($('.pika-single').hasClass('is-hidden'), false, "date picker is shown");
+  });
+});
+
 test("it updates displayed value when bound date changes", function() {
   component = this.subject();
 
@@ -149,3 +164,84 @@ test("it respects `valueFormat` when setting date value", function() {
     equal(component.get('date'), moment("2000-01-01").format('dddd, MMMM Do YYYY'), "sets currect date");
   });
 });
+
+/**
+ * Test `utc` option that creates date objects in UTC mode.
+ */
+test("it creates UTC timestamp when `utc: true`", function() {
+  component = this.subject();
+
+  fillIn(this.$(), "2000-01-01");
+
+  andThen(function() {
+    // simulate open + close of picker
+    component.get('_picker').show();
+    component.get('_picker').hide();
+
+    // actual UTC unix timestamp of "2000-01-01, 00:00:00"
+    var unixTimestamp2000 = 946684800;
+
+    // without utc = true, expect timestamp that differs from UTC unix timestamp
+    // by the current timezoneOffset in seconds
+    equal(component.get('date'), unixTimestamp2000 + (new Date()).getTimezoneOffset()*60,
+      "outputs timestamp that differs by timezoneOffset when utc = false");
+
+    component.set('utc', true);
+
+    // simulate open + close of picker
+    component.get('_picker').show();
+    component.get('_picker').hide();
+
+    equal(component.get('date'), unixTimestamp2000,
+      "outputs exact timestamp of date when utc = true");
+  });
+});
+
+test("it creates UTC date object when `utc: true`", function() {
+  component = this.subject({
+    valueFormat: 'date'
+  });
+
+  fillIn(this.$(), "2000-01-01");
+
+  andThen(function() {
+    // simulate open + close of picker
+    component.get('_picker').show();
+    component.get('_picker').hide();
+
+    equal(component.get('date').toISOString(), moment("2000-01-01").toDate().toISOString(),
+      "outputs regular date that equals locally generated date when utc = false");
+
+    component.set('utc', true);
+
+    // simulate open + close of picker again
+    component.get('_picker').show();
+    component.get('_picker').hide();
+
+    equal(component.get('date').toISOString(), "2000-01-01T00:00:00.000Z",
+      "outputs regular date that equals utc date when utc = true");
+  });
+});
+
+
+/*
+  This test makes PhantomJS fail because of the click(document.body) which's
+  event handling seems off compared to Chrome/FF :(
+
+  test("it hides date picker after click outside", function() {
+    expect(2);
+    component = this.subject();
+
+    // initial render
+    this.$();
+
+    equal($('.pika-single').hasClass('is-hidden'), true, "date picker is initially hidden");
+
+    click(this.$());
+    click(document.body);
+
+    andThen(function() {
+      equal($('.pika-single').hasClass('is-hidden'), true, "date picker is hidden again");
+    });
+  });
+*/


### PR DESCRIPTION
Hi! Again, I found myself in need of a feature I wanted to implement correctly. The code change is minimal, but the feature is probably not too easy to understand. I hope I nailed it in the readme:

---
#### utc

Type: `Boolean`
Default: `false`

Per default, the created `date` value will obtain the computer's timezone and
therefore not have UTC midnight as its time and will be a few hours off instead.

For example, when your timezone is 8 hours ahead of UTC: Creating a date object
from the input `"2000-01-01"` will result in `"1999-12-31T16:00:00.000Z"`,
because when your computer has the time of 00:00:00 on Jan 1st 2000, UTC time is
still in 1999. This is technically correct, but may not be what you want.

If you want to have easy-to-compare date strings in your JSON, set `utc` to `true`
and you will get `"2000-01-01T00:00:00.000Z"` as expected.

---

Also, as mentioned in Issue #6, I introduced a short changelog so it's easier to keep track of changes (who would have guessed? ;)).

Since this is a new feature and a (non-breaking) API change, I pushed the version number to 1.2.0 if that's ok for you? 2 new test cases were introduced that test the new option.
