### PR TITLE
String.fmt is deprecated in Ember 2.0

### DIFF
--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -11,7 +11,9 @@ export default Em.TextField.extend({
   date: null,
   yearRange: function() {
     var cy = window.moment().year();
-    return "%@,%@".fmt(cy-3, cy+4);
+    var startRange = cy - 3;
+    var endRange = cy + 4;
+    return `${startRange},${endRange}`;
   }.property(), // default yearRange from -3 to +4 years
   // A private method which returns the year range in absolute terms
   _yearRange: function() {


### PR DESCRIPTION
We should use ES6 template strings instead

> Ember.String.fmt is deprecated, use ES6 template strings instead. [deprecation id: ember-string-utils.fmt] See https://babeljs.io/docs/learn-es6/#template-strings for more details.
