### PR TITLE
Fix deprecation warnings

### DIFF
--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -11,7 +11,7 @@ export default Em.TextField.extend({
   date: null,
   yearRange: function() {
     var cy = window.moment().year();
-    return "%@,%@".fmt(cy-3, cy+4);
+    return `${cy-3},${cy+4}`;
   }.property(), // default yearRange from -3 to +4 years
   // A private method which returns the year range in absolute terms
   _yearRange: function() {


### PR DESCRIPTION
Ember throwing deprecation warnings from calling "set" within the didInsertElement hook, and for using Ember.String.fmt instead of ES6 template string syntax.

I just caused the body of didInsertElement to be scheduled to run on 'afterRender'.
