### PR TITLE
Fix String.fmt deprecation notice

### DIFF
--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -11,7 +11,9 @@ export default Em.TextField.extend({
   date: null,
   yearRange: function() {
     var cy = window.moment().year();
-    return "%@,%@".fmt(cy-3, cy+4);
+    let initialYear = cy - 3;
+    let endYear = cy + 4;
+    return `${initialYear},${endYear}`;
   }.property(), // default yearRange from -3 to +4 years
   // A private method which returns the year range in absolute terms
   _yearRange: function() {


### PR DESCRIPTION
New versions of ember deprecate the use of Ember.String.fmt
in favor of string literals from ES6